### PR TITLE
ST7036demo.cpp - add LCD.h

### DIFF
--- a/ST7036demo.cpp
+++ b/ST7036demo.cpp
@@ -1,3 +1,4 @@
+#include "LCD.h"
 #include "ST7036.h"
 
 ST7036 lcd = ST7036 ( 2, 20, 0x78 ); //2 lines, 20 characters, 0x78 address


### PR DESCRIPTION
This is not strictly necessary (already included by ST7036.h) but it quiets a warning from the Particle development IDE.
